### PR TITLE
Fix binder build.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,12 +1,12 @@
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - bokeh=0.13
-  - dask==0.19.0
-  - dask-ml==0.9.0
-  - distributed==1.23.0
-  - jupyterlab
+  - dask=0.19.0
+  - dask-ml=0.9.0
+  - distributed=1.23.0
+  - jupyterlab=0.34
+  - nodejs=8.9
   - numpy
   - pandas
   - pyarrow==0.10.0

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,6 +7,6 @@ jupyter labextension install dask-labextension
 sed -i -e "s|DASK_DASHBOARD_URL|/user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
 
 # Copy into the workspaces directory
-# TODO: what is the right filename to specify?
-# cp jupyterlab-workspace.json /home/jovyan/.jupyter/lab/workspaces 
+mkdir -p /home/jovyan/.jupyter/lab/workspaces
+cp ./binder/jupyterlab-workspace.json /home/jovyan/.jupyter/lab/workspaces/user${JUPYTERHUB_USER}lab-2f5d.jupyterlab-workspace
 


### PR DESCRIPTION
This fixes the binder build. It also correctly picks up the dashboard URL using the search button, so that is good.

The bad news is that I was unable to get the path munging working correctly. It may be that the random user uuid goes into the hash in the workspaces name. So we may have to wait until the workspaces CLI lands in JupyterLab before we can correctly get the saved layout to restore.